### PR TITLE
PE-728 - Fix the e-commerce playground documentation

### DIFF
--- a/eLearning/e-commerce-playground/README.md
+++ b/eLearning/e-commerce-playground/README.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: E-commerce playground
-permalink: /playground-e-commerce/
+permalink: /e-commerce-playground/
 ---
 
 <link rel="stylesheet" href="/lib/public/global-training.css">


### PR DESCRIPTION
This should resolve the first issue in the checklist at https://lucidworks.atlassian.net/browse/PE-728:

>The documentation does not load, even though it’s finished. To fix, change the documentation directory to e-commerce-playground and the permalink value to e-commerce-playground.